### PR TITLE
add better naming for routes

### DIFF
--- a/api/resources/Resource.py
+++ b/api/resources/Resource.py
@@ -5,7 +5,7 @@ class Resource:
     """
     
     model = None
-    methods = ['create', 'read', 'read_single', 'update', 'delete']
+    methods = ['create', 'index', 'show', 'update', 'delete']
     prefix = '/api'
     required_domain = None
     list_middleware = []
@@ -22,9 +22,9 @@ class Resource:
         for method in self.methods:
             if method == 'create':
                 routes.append(self.__class__(self.route_url, 'POST'))
-            elif method == 'read':
+            elif method == 'index':
                 routes.append(self.__class__(self.route_url, 'GET'))
-            elif method == 'read_single':
+            elif method == 'show':
                 routes.append(self.__class__(self.route_url + '/@id', 'GET'))
             elif method == 'update':
                 routes.append(self.__class__(self.route_url + '/@id', 'PUT'))
@@ -116,12 +116,12 @@ class Resource:
         """
         pass
         
-    def read(self): 
+    def index(self): 
         """Logic to read data from a given model
         """
         return self.model.all().serialize()
 
-    def read_single(self): 
+    def show(self): 
         """Logic to read data from a given model
         """
         return self.model.find(self.request.param('id')).to_dict()


### PR DESCRIPTION
reference:

Phoenix Framework
```
user_path  GET     /users           HelloWeb.UserController :index
user_path  GET     /users/:id/edit  HelloWeb.UserController :edit
user_path  GET     /users/new       HelloWeb.UserController :new
user_path  GET     /users/:id       HelloWeb.UserController :show
user_path  POST    /users           HelloWeb.UserController :create
user_path  PATCH   /users/:id       HelloWeb.UserController :update
           PUT     /users/:id       HelloWeb.UserController :update
user_path  DELETE  /users/:id       HelloWeb.UserController :delete
```

Rails:
```
GET	/photos	photos#index	display a list of all photos
GET	/photos/new	photos#new	return an HTML form for creating a new photo
POST	/photos	photos#create	create a new photo
GET	/photos/:id	photos#show	display a specific photo
GET	/photos/:id/edit	photos#edit	return an HTML form for editing a photo
PATCH/PUT	/photos/:id	photos#update	update a specific photo
DELETE	/photos/:id	photos#destroy	delete a specific photo
```