### PR TITLE
explicitly check @id to resolve show method

### DIFF
--- a/api/resources/Resource.py
+++ b/api/resources/Resource.py
@@ -59,7 +59,7 @@ class Resource:
         if not response:
             if 'POST' in self.method_type:
                 response = self.request.app().resolve(getattr(self, 'create'))
-            elif 'GET' in self.method_type and '@' in self.route_url:
+            elif 'GET' in self.method_type and '@id' in self.route_url:
                 response = self.request.app().resolve(getattr(self, 'show'))
             elif 'GET' in self.method_type:
                 response = self.request.app().resolve(getattr(self, 'index'))


### PR DESCRIPTION
when the route already has `@`, say, `/api/articles/@slug/comments` it fails and goes to show method instead of index.